### PR TITLE
Update upstream OpenTelemetry agent dependencies to 2.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ opentelemetryProto = "1.3.2-alpha"
 
 # otel agent, we rely on the '*-alpha' and get the non-alpha dependencies transitively
 # updated from upstream agent with .ci/update-upstream.sh
-opentelemetryJavaagentAlpha = "2.4.0-alpha"
+opentelemetryJavaagentAlpha = "2.6.0-alpha"
 
 # otel contrib
 # updated from upstream agent with .ci/update-upstream.sh

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ opentelemetryContribAlpha = "1.33.0-alpha"
 # updated from upstream agent with .ci/update-upstream.sh
 # While the semconv stable artifact is provided transitively by the agent, we still have to explicitly
 # reference the "incubating" version explicitly
-opentelemetrySemconvAlpha = "1.24.0-alpha"
+opentelemetrySemconvAlpha = "1.25.0-alpha"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ opentelemetryJavaagentAlpha = "2.6.0-alpha"
 
 # otel contrib
 # updated from upstream agent with .ci/update-upstream.sh
-opentelemetryContribAlpha = "1.33.0-alpha"
+opentelemetryContribAlpha = "1.36.0-alpha"
 
 # otel semconv
 # updated from upstream agent with .ci/update-upstream.sh


### PR DESCRIPTION


@elastic/apm-agent-java, can you please approve and merge this PR?


---



<Actions>
    <action id="2370090022548352370298855724627f7945c7d64a355c6c7d1221ca3289fcc7">
        <h3>Upgrade the upstream agent version and related transitive dependencies</h3>
        <details id="2ce51971e74981e9d16acb1cab904d9540949d6ce5c300b14025bb151914ae1e">
            <summary>Update OpenTelemetry Contrib version</summary>
            <p>1 file(s) updated with &#34;$1\&#34;1.36.0-alpha\&#34;&#34;:&#xA;&#x9;* gradle/libs.versions.toml&#xA;</p>
        </details>
        <details id="46391681425b73aa6ef22b73076eea71dc96de6a1a8d292eaeb025500e29204a">
            <summary>Update OpenTelemetry SemConv version</summary>
            <p>1 file(s) updated with &#34;$1\&#34;1.25.0-alpha\&#34;&#34;:&#xA;&#x9;* gradle/libs.versions.toml&#xA;</p>
        </details>
        <details id="41b45edc3907becee9cae4a071a858464f937f92ff671f5cd789a0542d6b8f6b">
            <summary>Update upstream OpenTelemetry agent version</summary>
            <p>1 file(s) updated with &#34;$1\&#34;2.6.0-alpha\&#34;&#34;:&#xA;&#x9;* gradle/libs.versions.toml&#xA;</p>
            <details>
                <summary>2.6.0</summary>
                <pre>&#xA;Release published on the 2024-07-17 01:42:03 +0000 UTC at the url https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.6.0&#xA;&#xA;This release targets the OpenTelemetry SDK 1.40.0.&#xA;&#xA;Note that many artifacts have the `-alpha` suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the [VERSIONING.md](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning) for more details.&#xA;&#xA; The Spring Boot Starter (`opentelemetry-spring-boot-starter`) is now stable.&#xA;&#xA;### Migration notes&#xA;&#xA;- The `opentelemetry-spring-boot` and `opentelemetry-spring-boot-3` artifacts have been merged into a single artifact named `opentelemetry-spring-boot-autoconfigure` which supports both Spring Boot 2 and Spring Boot 3&#xA;- Two experimental HTTP metrics have been renamed:  - `http.server.request.size` &amp;rarr; `http.server.request.body.size`,  - `http.server.response.size` &amp;rarr; `http.server.response.body.size`&#xA;&#xA;### 🌟 New javaagent instrumentation&#xA;&#xA;- Javalin ([#11587](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11587))&#xA;- ClickHouse ([#11660](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11660))&#xA;&#xA;### 📈 Enhancements&#xA;&#xA;- Support HTTP client instrumentation configuration in Spring starter ([#11620](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11620))&#xA;- Influxdb client: don&#39;t fill `db.statement` for create/drop database and write operations ([#11557](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11557))&#xA;- Support `otel.instrumentation.common.default-enabled` in the Spring starter ([#11746](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11746))&#xA;- Support Jetty HTTP client 12 ([#11519](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11519))&#xA;- Add Pulsar `messaging.producer.duration` metric ([#11591](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11591))&#xA;- Improve instrumentation suppression behavior ([#11640](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11640))&#xA;- Propagate OpenTelemetry context through custom AWS client context for Lambda direct calls ([#11675](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11675))&#xA;- Spring Native support for `@WithSpan` ([#11757](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11757))&#xA;- Support HTTP server instrumentation config properties in the Spring starter ([#11667](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11667))&#xA;&#xA;### 🛠️ Bug fixes&#xA;&#xA;- Fix `http.server.active_requests` metric with async requests ([#11638](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11638))&#xA;&#xA;### 🙇 Thank you&#xA;&#xA;This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:&#xA;&#xA;@123liuziming&#xA;@breedx-splk&#xA;@crossoverJie&#xA;@devurandom&#xA;@heyams&#xA;@jaydeluca&#xA;@jeanbisutti&#xA;@johnbley&#xA;@JonasKunz&#xA;@laurit&#xA;@lucasamoroso&#xA;@pandaji&#xA;@steverao&#xA;@SylvainJuge&#xA;@trask&#xA;@tylerbenson&#xA;@xiepuhuan&#xA;@Yindazz&#xA;@zeitlinger&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

